### PR TITLE
fix CopyToAsyncCore - cancellation and infinite loop

### DIFF
--- a/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -113,9 +113,9 @@ namespace System.IO.Pipelines
             {
                 SequencePosition consumed = default;
 
+                ReadResult result = await ReadAsync(cancellationToken).ConfigureAwait(false);
                 try
                 {
-                    ReadResult result = await ReadAsync(cancellationToken).ConfigureAwait(false);
                     ReadOnlySequence<byte> buffer = result.Buffer;
                     SequencePosition position = buffer.Start;
 
@@ -130,7 +130,12 @@ namespace System.IO.Pipelines
 
                         consumed = position;
                     }
-
+                    
+                    if (consumed.Equals(default(SequencePosition)) 
+                    {
+                        consumed = buffer.End;
+                    }
+                        
                     if (result.IsCompleted)
                     {
                         break;


### PR DESCRIPTION
ReadResult result = await ReadAsync(cancellationToken).ConfigureAwait(false); should be before the try/finally block because if you cancel the read operation the finally clause will try to advance reader that is not in reading state and instead of OperationCancelledException you will end up with InvalidOperationException.

There is a bug either in PipeReader.CopyToAsyncCore() or ReadOnlySequence.TryGet():

When ReadOnlySequence.TryGet() reaches final segment it will return true and this final memory but it will also set position as default(SequencePosition) - I don't know if this is by design but CopyToAsyncCore() method does not take it in consideration and it will copy the memory but not advance the reader - this will cause it to repeat this data indefinitely.